### PR TITLE
Fixed README compilation instruction.

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Dependencies:
 Basic *nix build instructions:
 	./autogen.sh	# only needed if building from git repo
 	./nomacro.pl	# only needed if building on Mac OS X or with Clang
-	./configure CFLAGS="-O3"
+	./configure CFLAG="-O3"
 	make
 
 Notes for AIX users:


### PR DESCRIPTION
Hey, you have forgot the 's' character ;)
Compilation of cpuminer goes with `./configure CFLAG="-03"` not `CFLAGS="-03"`
